### PR TITLE
fix: prevent stdout log from breaking JSON-RPC handshake in MCP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -38,7 +38,7 @@ const transport = new StdioServerTransport();
 server
 	.connect(transport)
 	.then(() => {
-		console.log(`Starwind UI MCP Server running (using stdio transport)`);
+		console.error(`Starwind UI MCP Server running (using stdio transport)`);
 	})
 	.catch(console.error);
 


### PR DESCRIPTION
### What

Moves the `console.log("Starwind UI MCP Server running...")` line to `console.error`.

### Why

Claude (and other LLMs using `stdio`-based MCP) expect stdout to be a clean JSON-RPC stream.
The original startup message was sent to stdout, which broke protocol compliance—
causing JSON parse errors like: SyntaxError: Unexpected token 'S', "Starwind U"... is not valid JSON

By redirecting this log to stderr, we preserve clean separation between human-readable
logs and machine-readable protocol messages.

